### PR TITLE
[FEAT] Added input task on errors and fails

### DIFF
--- a/lib/task.js
+++ b/lib/task.js
@@ -54,9 +54,10 @@ Task.prototype.report = function () {
 
 Task.prototype.succeed = function (res) {
 	this.worker.succeed({
+		input: this.input,
 		output: res,
 		taskToken: this.taskToken,
-		workerName: this.workerName
+		workerName: this.workerName,
 	});
 	this.emit('finish');
 };
@@ -64,6 +65,7 @@ Task.prototype.succeed = function (res) {
 Task.prototype.fail = function (err) {
 	this.worker.fail({
 		error: err,
+		input: this.input,
 		taskToken: this.taskToken,
 		workerName: this.workerName
 	});
@@ -72,6 +74,7 @@ Task.prototype.fail = function (err) {
 
 Task.prototype.heartbeat = function () {
 	this.worker.heartbeat({
+		input: this.input,
 		taskToken: this.taskToken,
 		workerName: this.workerName
 	});

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -126,9 +126,10 @@ Worker.prototype.execute = function (input, cb, heartbeat) {
 Worker.prototype.succeed = function (res) {
 	const params = Object.assign({}, res, {output: JSON.stringify(res.output)});
 	delete params.workerName;
+	delete params.input;
 	stepfunction.sendTaskSuccess(params, err => {
 		if (err) {
-			this.emit('error', err);
+			this.emit('error', {err: err, input: res.input});
 		} else {
 			this.emit('success', res);
 		}
@@ -145,10 +146,11 @@ Worker.prototype.fail = function (res) {
 	}
 	const params = Object.assign({}, res, {error});
 	delete params.workerName;
+	delete params.input;
 	this.logger.debug('sendTaskFailure', res.error);
 	stepfunction.sendTaskFailure(params, err => {
 		if (err) {
-			this.emit('error', err);
+			this.emit('error', {err: err, input: res.input});
 		} else {
 			this.emit('failure', res);
 		}
@@ -158,11 +160,12 @@ Worker.prototype.fail = function (res) {
 Worker.prototype.heartbeat = function (res) {
 	const params = Object.assign({}, res);
 	delete params.workerName;
+	delete params.input;
 	this.logger.debug('sendTaskHeartbeat');
 
 	stepfunction.sendTaskHeartbeat(params, err => {
 		if (err) {
-			this.emit('error', err);
+			this.emit('error', {err: err, input: res.input});
 		} else {
 			this.emit('heartbeat', res);
 		}


### PR DESCRIPTION
When a task failed, eg. an user abort from aws step functions console, I couldn't handle the input parameters of the aborted task. I was missing it and I wanted to track the input in case of fail.