### PR TITLE
[Feature] Avoid racing condition on task execution.

### DIFF
--- a/lib/pooler.js
+++ b/lib/pooler.js
@@ -3,8 +3,6 @@ const EventEmitter = require('events').EventEmitter;
 const AWS = require('aws-sdk');
 const Task = require('./task.js');
 
-const stepfunction = new AWS.StepFunctions();
-
 /**
 * @class Pooler
 * @param {object} options
@@ -16,6 +14,7 @@ const stepfunction = new AWS.StepFunctions();
 function Pooler(options) {
 	EventEmitter.call(this);
 
+	this.stepfunction = options.stepfunction;
 	this._running = true;
 	this._task = false;
 	this.logger = options.logger;
@@ -82,7 +81,7 @@ Pooler.prototype.pool = function () {
 
 Pooler.prototype.getActivityTask = function () {
 	this.logger.debug(this.workerName + ' getActivityTask ' + this.activityArn);
-	this._request = stepfunction.getActivityTask({
+	this._request = this.stepfunction.getActivityTask({
 		activityArn: this.activityArn,
 		workerName: this.workerName
 	}, (err, data) => {

--- a/lib/pooler.js
+++ b/lib/pooler.js
@@ -107,6 +107,8 @@ Pooler.prototype.getActivityTask = function () {
 				this._task = null;
 				this.pool();
 			});
+
+			this._task.execute();
 		} else {
 			this.pool();
 		}

--- a/lib/task.js
+++ b/lib/task.js
@@ -19,9 +19,12 @@ function Task(options) {
 	this.input = options.input;
 	this.taskToken = options.taskToken;
 	this.workerName = options.workerName;
+}
+
+Task.prototype.execute = function() {
 	this.startTime = new Date();
 	this.worker.execute(this.input, this.taskCallback.bind(this), this.heartbeat.bind(this));
-}
+};
 
 Task.prototype.taskCallback = function (err, res) {
 	if (err) {

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -2,7 +2,6 @@ const EventEmitter = require('events').EventEmitter;
 const util = require('util');
 const AWS = require('aws-sdk');
 
-const stepfunction = new AWS.StepFunctions();
 const Pooler = require('./pooler.js');
 const replaceError = require('./replace-error.js');
 
@@ -28,6 +27,14 @@ function Worker(options) {
 	}
 
 	this.concurrency = typeof (options.concurrency) === 'number' ? options.concurrency : 1;
+
+	if (!options.region) {
+		this.emit('error', new Error('region is mandatory inside Worker'))
+	}
+
+	this.stepfunction = new AWS.StepFunctions({
+		region: options.region,
+	})
 
 	this.activityArn = options.activityArn;
 	this.workerName = options.workerName;
@@ -85,6 +92,7 @@ Worker.prototype.updatePool = function (cb) {
 
 Worker.prototype.addPooler = function (index) {
 	const pooler = new Pooler({
+		stepfunction: this.stepfunction,
 		activityArn: this.activityArn,
 		workerName: this.workerName,
 		worker: this,
@@ -126,7 +134,7 @@ Worker.prototype.execute = function (input, cb, heartbeat) {
 Worker.prototype.succeed = function (res) {
 	const params = Object.assign({}, res, {output: JSON.stringify(res.output)});
 	delete params.workerName;
-	stepfunction.sendTaskSuccess(params, err => {
+	this.stepfunction.sendTaskSuccess(params, err => {
 		if (err) {
 			this.emit('error', err);
 		} else {
@@ -146,7 +154,7 @@ Worker.prototype.fail = function (res) {
 	const params = Object.assign({}, res, {error});
 	delete params.workerName;
 	this.logger.debug('sendTaskFailure', res.error);
-	stepfunction.sendTaskFailure(params, err => {
+	this.stepfunction.sendTaskFailure(params, err => {
 		if (err) {
 			this.emit('error', err);
 		} else {
@@ -160,7 +168,7 @@ Worker.prototype.heartbeat = function (res) {
 	delete params.workerName;
 	this.logger.debug('sendTaskHeartbeat');
 
-	stepfunction.sendTaskHeartbeat(params, err => {
+	this.stepfunction.sendTaskHeartbeat(params, err => {
 		if (err) {
 			this.emit('error', err);
 		} else {

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -28,13 +28,13 @@ function Worker(options) {
 
 	this.concurrency = typeof (options.concurrency) === 'number' ? options.concurrency : 1;
 
-	if (!options.region) {
-		this.emit('error', new Error('region is mandatory inside Worker'))
+	if (this.options.region) {
+		this.stepfunction = new AWS.StepFunctions({
+			region: options.region,
+		});
+	} else {
+		this.stepfunction = new AWS.StepFunctions();
 	}
-
-	this.stepfunction = new AWS.StepFunctions({
-		region: options.region,
-	})
 
 	this.activityArn = options.activityArn;
 	this.workerName = options.workerName;


### PR DESCRIPTION
We are using this code in production to avoid the case when the execution fails or returns before any listeners are attached. 