### PR TITLE
Feature/restart activity worker

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -131,17 +131,17 @@ Worker.prototype.close = function (cb) {
 };
 
 Worker.prototype.restart = function (cb) {
-  this.logger.info('Restarting the worker ... this might take 60 seconds');
-  const oldConcurrency = this.concurrency;
+	this.logger.info('Restarting the worker ... this might take 60 seconds');
+	const oldConcurrency = this.concurrency;
 	this.concurrency = 0;
 	this.updatePool(() => {
 		this.logger.info('Worker closed');
-    this.concurrency = oldConcurrency;
-    this.updatePool(err => {
-      this.logger.info('Worker started');
-      cb(err);
-    });
-  });
+		this.concurrency = oldConcurrency;
+		this.updatePool(err => {
+			this.logger.info('Worker started');
+			cb(err);
+		});
+	});
 };
 
 Worker.prototype.execute = function (input, cb, heartbeat) {

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -130,6 +130,20 @@ Worker.prototype.close = function (cb) {
 	this.removeAllListeners();
 };
 
+Worker.prototype.restart = function (cb) {
+  this.logger.info('Restarting the worker ... this might take 60 seconds');
+  const oldConcurrency = this.concurrency;
+	this.concurrency = 0;
+	this.updatePool(() => {
+		this.logger.info('Worker closed');
+    this.concurrency = oldConcurrency;
+    this.updatePool(err => {
+      this.logger.info('Worker started');
+      cb(err);
+    });
+  });
+};
+
 Worker.prototype.execute = function (input, cb, heartbeat) {
 	setImmediate(() => {
 		try {


### PR DESCRIPTION
Sometimes, in case of unhandled error, I want to restart the worker instead of calling `process.exit` and relying on recluster to restart the app.
`worker.close` will effectively remove the listeners and reduce the number of pools to 0. That is why i couldn't just call `close -> start`.